### PR TITLE
feat: fetch latest release automatically

### DIFF
--- a/install-dcl-cli
+++ b/install-dcl-cli
@@ -1,6 +1,9 @@
 #!/bin/bash
-RELEASE_URL="https://github.com/witnesschain-com/dcl-operator-cli/releases/download/v0.0.8"
 APP_NAME="witness-cli"
+export VERSION=`curl --silent -L   -H "Accept: application/vnd.github+json"    -H "X-GitHub-Api-Version: 2022-11-28"   https://api.github.com/repos/witnesschain-com/dcl-operator-cli/releases/latest | grep tag_name| cut -d "\"" -f 4`
+
+echo "${APP_NAME} version: " $VERSION
+RELEASE_URL="https://github.com/witnesschain-com/dcl-operator-cli/releases/download/$VERSION"
 
 CHALLENGER_CONFIG_URL="https://raw.githubusercontent.com/witnesschain-com/dcl-operator-cli/main/dcl-operator/operator-challenger-config.json.template"
 PROVER_CONFIG_URL="https://raw.githubusercontent.com/witnesschain-com/dcl-operator-cli/main/dcl-operator/operator-prover-config.json.template"

--- a/install-dcl-cli
+++ b/install-dcl-cli
@@ -96,7 +96,7 @@ fi
 print_info "Prover config template: $PWD/config/operator-prover-config.json.template"
 printf "\n"
 
-printf "\n\n- 🏃 Downloading $APP_NAME...\n"
+printf "\n\n- 🏃 Downloading $APP_NAME ($RELEASE_URL/$BINARY_NAME)...\n"
 curl -# -fSL  -o "$APP_NAME" "$RELEASE_URL/$BINARY_NAME"
 if [ $? = 0 ]; then
     print_success "  ✅ Download completed. "

--- a/install-dcl-cli
+++ b/install-dcl-cli
@@ -51,13 +51,13 @@ if [ "$PLATFORM" = "Linux" ] && [ "$ARCH" = "x86_64" ]; then
     printf "\n"
     print_success "    Architecture: x86_64"
     printf "\n"
-    BINARY_NAME="dcl-operator_linux_x86_64"
+    BINARY_NAME="witnesschain-cli_linux_x86_64"
 elif [ "$PLATFORM" = "Darwin" ] && [ "$ARCH" = "arm64" ]; then
     print_success "    Operating Systems: macOS\n"
     printf "\n"
     print_success "    Architecture: arm64\n"
     printf "\n"
-    BINARY_NAME="dcl-operator_apple_silicon"
+    BINARY_NAME="witnesschain-cli_apple_silicon"
 else
     print_error " Unable to identify platform for the binaries, please setup manually"
     printf "\n"


### PR DESCRIPTION
This pull request fetches the latest release version of `dcl-operator-cli`, thus we don't need to manually update the `dcl-install-script` whenever we create new releases of `dcl-operator-cli`

- [x] Tested on Linux
- [x]  Testing on MacOS

